### PR TITLE
Task 3: Intent-Based Natural Language Routing

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -3,6 +3,7 @@
 Run modes:
   uv run bot.py                          — start Telegram bot
   uv run bot.py --test "/start"          — test a command offline (no Telegram)
+  uv run bot.py --test "what labs?"      — test intent router offline
 """
 
 import asyncio
@@ -16,16 +17,26 @@ from handlers.commands import (
     handle_scores,
     handle_start,
 )
+from handlers.router import route
+from services.llm_client import LLMClient
 from services.lms_client import LMSClient
 
 
-def make_client() -> LMSClient:
+def make_lms() -> LMSClient:
     return LMSClient(base_url=settings.lms_api_url, api_key=settings.lms_api_key)
 
 
+def make_llm() -> LLMClient:
+    return LLMClient(
+        base_url=settings.llm_api_base_url,
+        api_key=settings.llm_api_key,
+        model=settings.llm_api_model,
+    )
+
+
 async def dispatch(text: str) -> str:
-    """Route a command string to the right handler and return its response."""
-    client = make_client()
+    """Route text to the right handler."""
+    lms = make_lms()
     text = text.strip()
 
     if text == "/start":
@@ -33,15 +44,18 @@ async def dispatch(text: str) -> str:
     if text == "/help":
         return await handle_help()
     if text == "/health":
-        return await handle_health(client)
+        return await handle_health(lms)
     if text == "/labs":
-        return await handle_labs(client)
+        return await handle_labs(lms)
     if text.startswith("/scores"):
         parts = text.split(maxsplit=1)
         lab = parts[1] if len(parts) > 1 else ""
-        return await handle_scores(lab, client)
+        return await handle_scores(lab, lms)
+    if text.startswith("/"):
+        return "Unknown command. Type /help to see available commands."
 
-    return "Unknown command. Type /help to see available commands."
+    # Plain text → intent router
+    return await route(text, lms, make_llm())
 
 
 # ---------------------------------------------------------------------------
@@ -50,8 +64,7 @@ async def dispatch(text: str) -> str:
 
 
 async def run_test(command: str) -> None:
-    response = await dispatch(command)
-    print(response)
+    print(await dispatch(command))
 
 
 # ---------------------------------------------------------------------------
@@ -62,14 +75,31 @@ async def run_test(command: str) -> None:
 async def run_bot() -> None:
     from aiogram import Bot, Dispatcher
     from aiogram.filters import Command
-    from aiogram.types import Message
+    from aiogram.types import (
+        InlineKeyboardButton,
+        InlineKeyboardMarkup,
+        Message,
+        CallbackQuery,
+    )
 
     bot = Bot(token=settings.bot_token)
     dp = Dispatcher()
 
+    def start_keyboard() -> InlineKeyboardMarkup:
+        return InlineKeyboardMarkup(inline_keyboard=[
+            [
+                InlineKeyboardButton(text="📋 Labs", callback_data="labs"),
+                InlineKeyboardButton(text="❤️ Health", callback_data="health"),
+            ],
+            [
+                InlineKeyboardButton(text="📊 Scores lab-04", callback_data="scores_lab-04"),
+                InlineKeyboardButton(text="📊 Scores lab-07", callback_data="scores_lab-07"),
+            ],
+        ])
+
     @dp.message(Command("start"))
     async def on_start(message: Message) -> None:
-        await message.answer(await handle_start())
+        await message.answer(await handle_start(), reply_markup=start_keyboard())
 
     @dp.message(Command("help"))
     async def on_help(message: Message) -> None:
@@ -77,17 +107,33 @@ async def run_bot() -> None:
 
     @dp.message(Command("health"))
     async def on_health(message: Message) -> None:
-        await message.answer(await handle_health(make_client()))
+        await message.answer(await handle_health(make_lms()))
 
     @dp.message(Command("labs"))
     async def on_labs(message: Message) -> None:
-        await message.answer(await handle_labs(make_client()))
+        await message.answer(await handle_labs(make_lms()))
 
     @dp.message(Command("scores"))
     async def on_scores(message: Message) -> None:
         parts = (message.text or "").split(maxsplit=1)
         lab = parts[1] if len(parts) > 1 else ""
-        await message.answer(await handle_scores(lab, make_client()))
+        await message.answer(await handle_scores(lab, make_lms()))
+
+    @dp.callback_query()
+    async def on_callback(callback: CallbackQuery) -> None:
+        data = callback.data or ""
+        lms = make_lms()
+        if data == "labs":
+            text = await handle_labs(lms)
+        elif data == "health":
+            text = await handle_health(lms)
+        elif data.startswith("scores_"):
+            lab = data[len("scores_"):]
+            text = await handle_scores(lab, lms)
+        else:
+            text = await route(data, lms, make_llm())
+        await callback.message.answer(text)  # type: ignore[union-attr]
+        await callback.answer()
 
     @dp.message()
     async def on_text(message: Message) -> None:

--- a/bot/handlers/router.py
+++ b/bot/handlers/router.py
@@ -1,0 +1,189 @@
+"""Intent router — routes plain-text messages through the LLM tool-calling loop."""
+
+import json
+import sys
+
+from services.llm_client import LLMClient
+from services.lms_client import LMSClient
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_items",
+            "description": "List all labs and tasks available in the LMS",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_learners",
+            "description": "List enrolled students and their groups",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_scores",
+            "description": "Get score distribution (4 buckets: 0-25%, 25-50%, 50-75%, 75-100%) for a lab",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "lab": {"type": "string", "description": "Lab identifier, e.g. 'lab-04'"}
+                },
+                "required": ["lab"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_pass_rates",
+            "description": "Get per-task average scores and attempt counts for a lab",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "lab": {"type": "string", "description": "Lab identifier, e.g. 'lab-04'"}
+                },
+                "required": ["lab"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_timeline",
+            "description": "Get number of submissions per day for a lab",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "lab": {"type": "string", "description": "Lab identifier, e.g. 'lab-04'"}
+                },
+                "required": ["lab"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_groups",
+            "description": "Get per-group average scores and student counts for a lab",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "lab": {"type": "string", "description": "Lab identifier, e.g. 'lab-04'"}
+                },
+                "required": ["lab"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_top_learners",
+            "description": "Get top N learners by score for a lab",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "lab": {"type": "string", "description": "Lab identifier, e.g. 'lab-04'"},
+                    "limit": {"type": "integer", "description": "Number of top learners to return (default 5)"},
+                },
+                "required": ["lab"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_completion_rate",
+            "description": "Get the completion rate percentage for a lab",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "lab": {"type": "string", "description": "Lab identifier, e.g. 'lab-04'"}
+                },
+                "required": ["lab"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "trigger_sync",
+            "description": "Refresh data from the autochecker (ETL sync)",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+]
+
+SYSTEM_PROMPT = (
+    "You are an LMS assistant bot. You have access to tools that fetch data from a "
+    "Learning Management System backend. When a user asks a question, use the appropriate "
+    "tools to get data, then provide a clear and concise answer. "
+    "For multi-step questions (e.g. 'which lab has the lowest pass rate'), call tools "
+    "for each lab and compare the results. Always use tools to answer data questions — "
+    "do not guess. If the question is a greeting or unrelated, respond helpfully and "
+    "mention what you can do."
+)
+
+
+async def _call_tool(name: str, args: dict, lms: LMSClient) -> str:
+    try:
+        if name == "get_items":
+            result = await lms.get_items()
+        elif name == "get_learners":
+            result = await lms.get_learners()
+        elif name == "get_scores":
+            result = await lms.get_scores(**args)
+        elif name == "get_pass_rates":
+            result = await lms.get_pass_rates(**args)
+        elif name == "get_timeline":
+            result = await lms.get_timeline(**args)
+        elif name == "get_groups":
+            result = await lms.get_groups(**args)
+        elif name == "get_top_learners":
+            result = await lms.get_top_learners(**args)
+        elif name == "get_completion_rate":
+            result = await lms.get_completion_rate(**args)
+        elif name == "trigger_sync":
+            result = await lms.trigger_sync()
+        else:
+            return f"Unknown tool: {name}"
+        return json.dumps(result)
+    except Exception as e:
+        return f"Error calling {name}: {e}"
+
+
+async def route(text: str, lms: LMSClient, llm: LLMClient) -> str:
+    messages: list[dict] = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": text},
+    ]
+
+    for _ in range(10):  # max iterations to prevent infinite loops
+        msg = await llm.chat(messages, tools=TOOLS)
+        tool_calls = msg.get("tool_calls")
+
+        if not tool_calls:
+            return msg.get("content") or "I couldn't generate a response."
+
+        # Execute all tool calls
+        messages.append(msg)
+        for tc in tool_calls:
+            name = tc["function"]["name"]
+            args = json.loads(tc["function"].get("arguments", "{}"))
+            print(f"[tool] LLM called: {name}({args})", file=sys.stderr)
+            result = await _call_tool(name, args, lms)
+            item_count = len(json.loads(result)) if result.startswith("[") else "-"
+            print(f"[tool] Result: {item_count} items", file=sys.stderr)
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tc["id"],
+                "content": result,
+            })
+
+        print(f"[summary] Feeding {len(tool_calls)} tool result(s) back to LLM", file=sys.stderr)
+
+    return "Could not complete the request after multiple steps."

--- a/bot/services/llm_client.py
+++ b/bot/services/llm_client.py
@@ -1,0 +1,21 @@
+import httpx
+
+
+class LLMClient:
+    def __init__(self, base_url: str, api_key: str, model: str) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._model = model
+
+    async def chat(self, messages: list[dict], tools: list[dict] | None = None) -> dict:
+        payload: dict = {"model": self._model, "messages": messages}
+        if tools:
+            payload["tools"] = tools
+        async with httpx.AsyncClient(timeout=120) as client:
+            resp = await client.post(
+                f"{self._base_url}/chat/completions",
+                headers={"Authorization": f"Bearer {self._api_key}"},
+                json=payload,
+            )
+            resp.raise_for_status()
+            return resp.json()["choices"][0]["message"]

--- a/bot/services/lms_client.py
+++ b/bot/services/lms_client.py
@@ -6,18 +6,44 @@ class LMSClient:
         self._base_url = base_url.rstrip("/")
         self._headers = {"Authorization": f"Bearer {api_key}"}
 
-    async def get_items(self) -> list[dict]:
+    async def _get(self, path: str, params: dict | None = None) -> list | dict:
         async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.get(f"{self._base_url}/items/", headers=self._headers)
+            resp = await client.get(
+                f"{self._base_url}{path}", headers=self._headers, params=params or {}
+            )
             resp.raise_for_status()
             return resp.json()
 
+    async def get_items(self) -> list[dict]:
+        return await self._get("/items/")  # type: ignore[return-value]
+
+    async def get_learners(self) -> list[dict]:
+        return await self._get("/learners/")  # type: ignore[return-value]
+
+    async def get_scores(self, lab: str) -> list[dict]:
+        return await self._get("/analytics/scores", {"lab": lab})  # type: ignore[return-value]
+
     async def get_pass_rates(self, lab: str) -> list[dict]:
-        async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.get(
-                f"{self._base_url}/analytics/pass-rates",
+        return await self._get("/analytics/pass-rates", {"lab": lab})  # type: ignore[return-value]
+
+    async def get_timeline(self, lab: str) -> list[dict]:
+        return await self._get("/analytics/timeline", {"lab": lab})  # type: ignore[return-value]
+
+    async def get_groups(self, lab: str) -> list[dict]:
+        return await self._get("/analytics/groups", {"lab": lab})  # type: ignore[return-value]
+
+    async def get_top_learners(self, lab: str, limit: int = 5) -> list[dict]:
+        return await self._get("/analytics/top-learners", {"lab": lab, "limit": limit})  # type: ignore[return-value]
+
+    async def get_completion_rate(self, lab: str) -> dict:
+        return await self._get("/analytics/completion-rate", {"lab": lab})  # type: ignore[return-value]
+
+    async def trigger_sync(self) -> dict:
+        async with httpx.AsyncClient(timeout=60) as client:
+            resp = await client.post(
+                f"{self._base_url}/pipeline/sync",
                 headers=self._headers,
-                params={"lab": lab},
+                json={},
             )
             resp.raise_for_status()
             return resp.json()


### PR DESCRIPTION
## Summary

- `services/llm_client.py` — OpenAI-compatible LLM client via httpx
- `handlers/router.py` — tool-calling loop: user text → LLM → tool calls → results → final answer
- 9 tool definitions covering all backend endpoints
- `bot.py` — plain text routed to intent router; `/start` shows inline keyboard buttons
- Debug logging to stderr: `[tool]`, `[summary]` lines

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)